### PR TITLE
feat(ai-sdk): add resumable streams example with Mastra memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-router": "^7.10.1",
     "react-syntax-highlighter": "^16.1.0",
     "remark-gfm": "^4.0.1",
+    "resumable-stream": "^2.2.10",
     "streamdown": "^1.6.10",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 0.0.44
       '@ag-ui/mastra':
         specifier: ^1.0.0
-        version: 1.0.0(7bcbdb0bd64f274638ec14726ca0df0f)
+        version: 1.0.0(e24a6692e9c574014baab4fa849dae45)
       '@ai-sdk/react':
         specifier: ^2.0.114
         version: 2.0.114(react@19.2.3)(zod@4.1.13)
@@ -31,13 +31,13 @@ importers:
         version: 0.11.6(@assistant-ui/react@0.11.47(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@copilotkit/react-core':
         specifier: ^1.51.3
-        version: 1.51.3(f82671d71421e3ac533b94cf78b71a2d)
+        version: 1.51.3(f47834045afc76bbb9437de40187a237)
       '@copilotkit/react-ui':
         specifier: ^1.51.3
-        version: 1.51.3(f82671d71421e3ac533b94cf78b71a2d)
+        version: 1.51.3(f47834045afc76bbb9437de40187a237)
       '@copilotkit/runtime':
         specifier: ^1.51.3
-        version: 1.51.3(18abf9104bf1c044ee998c61d0054e8e)
+        version: 1.51.3(2229ebd09135563f382da2ce03f7ff0f)
       '@icons-pack/react-simple-icons':
         specifier: ^13.8.0
         version: 13.8.0(react@19.2.3)
@@ -155,6 +155,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      resumable-stream:
+        specifier: ^2.2.10
+        version: 2.2.10
       streamdown:
         specifier: ^1.6.10
         version: 1.6.10(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.3)
@@ -551,6 +554,7 @@ packages:
   '@aws-sdk/middleware-websocket@3.972.3':
     resolution: {integrity: sha512-/BjMbtOM9lsgdNgRZWUL5oCV6Ocfx1vcK/C5xO5/t/gCk6IwR9JFWMilbk6K6Buq5F84/lkngqcCKU2SRkAmOg==}
     engines: {node: '>= 14.0.0'}
+    deprecated: Please update your @aws-sdk client to a more recent version, such as https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.982.0, if using browser-based WebSocket bidirectional streaming.
 
   '@aws-sdk/nested-clients@3.980.0':
     resolution: {integrity: sha512-/dONY5xc5/CCKzOqHZCTidtAR4lJXWkGefXvTRKdSKMGaYbbKsxDckisd6GfnvPSLxWtvQzwgRGRutMRoYUApQ==}
@@ -6632,6 +6636,9 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  resumable-stream@2.2.10:
+    resolution: {integrity: sha512-pSJtiDVkPgirq4x+e+gu67IEkUVYGu1cPgW5AnTHCfYGRfIUjS3d4pj7VGveXmYWb9hy6yIMFTM4YzK7rqj14A==}
+
   retry-axios@2.6.0:
     resolution: {integrity: sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==}
     engines: {node: '>=10.7.0'}
@@ -7574,12 +7581,12 @@ snapshots:
       - react
       - react-dom
 
-  '@ag-ui/mastra@1.0.0(7bcbdb0bd64f274638ec14726ca0df0f)':
+  '@ag-ui/mastra@1.0.0(e24a6692e9c574014baab4fa849dae45)':
     dependencies:
       '@ag-ui/client': 0.0.44
       '@ag-ui/core': 0.0.44
       '@ai-sdk/ui-utils': 1.2.11(zod@4.1.13)
-      '@copilotkit/runtime': 1.51.3(18abf9104bf1c044ee998c61d0054e8e)
+      '@copilotkit/runtime': 1.51.3(2229ebd09135563f382da2ce03f7ff0f)
       '@mastra/client-js': 1.1.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.13))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.13)
       '@mastra/core': 1.1.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.13))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.13)
       rxjs: 7.8.1
@@ -8769,10 +8776,10 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@copilotkit/react-core@1.51.3(f82671d71421e3ac533b94cf78b71a2d)':
+  '@copilotkit/react-core@1.51.3(f47834045afc76bbb9437de40187a237)':
     dependencies:
       '@ag-ui/client': 0.0.43
-      '@copilotkit/runtime-client-gql': 1.51.3(9cc577600ffeaed6dfc7d82bfa1f68ae)
+      '@copilotkit/runtime-client-gql': 1.51.3(34957286a2e41319aa29a853691c02c4)
       '@copilotkit/shared': 1.51.3(@ag-ui/core@0.0.44)
       '@copilotkitnext/core': 1.51.3
       '@copilotkitnext/react': 1.51.3(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -8808,10 +8815,10 @@ snapshots:
       - openai
       - supports-color
 
-  '@copilotkit/react-ui@1.51.3(f82671d71421e3ac533b94cf78b71a2d)':
+  '@copilotkit/react-ui@1.51.3(f47834045afc76bbb9437de40187a237)':
     dependencies:
-      '@copilotkit/react-core': 1.51.3(f82671d71421e3ac533b94cf78b71a2d)
-      '@copilotkit/runtime-client-gql': 1.51.3(9cc577600ffeaed6dfc7d82bfa1f68ae)
+      '@copilotkit/react-core': 1.51.3(f47834045afc76bbb9437de40187a237)
+      '@copilotkit/runtime-client-gql': 1.51.3(34957286a2e41319aa29a853691c02c4)
       '@copilotkit/shared': 1.51.3(@ag-ui/core@0.0.44)
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
@@ -8848,9 +8855,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@copilotkit/runtime-client-gql@1.51.3(9cc577600ffeaed6dfc7d82bfa1f68ae)':
+  '@copilotkit/runtime-client-gql@1.51.3(34957286a2e41319aa29a853691c02c4)':
     dependencies:
-      '@copilotkit/runtime': 1.51.3(18abf9104bf1c044ee998c61d0054e8e)
+      '@copilotkit/runtime': 1.51.3(2229ebd09135563f382da2ce03f7ff0f)
       '@copilotkit/shared': 1.51.3(@ag-ui/core@0.0.44)
       '@urql/core': 5.2.0(graphql@16.12.0)
       react: 19.2.3
@@ -8877,13 +8884,13 @@ snapshots:
       - openai
       - react-dom
 
-  '@copilotkit/runtime@1.51.3(18abf9104bf1c044ee998c61d0054e8e)':
+  '@copilotkit/runtime@1.51.3(2229ebd09135563f382da2ce03f7ff0f)':
     dependencies:
       '@ag-ui/client': 0.0.43
       '@ag-ui/core': 0.0.43
       '@ag-ui/langgraph': 0.0.23(@ag-ui/client@0.0.43)(@ag-ui/core@0.0.43)(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@copilotkit/shared': 1.51.3(@ag-ui/core@0.0.44)
-      '@copilotkitnext/agent': 1.51.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)
+      '@copilotkitnext/agent': 1.51.3(@cfworker/json-schema@4.1.1)(hono@4.11.7)
       '@copilotkitnext/runtime': 1.51.3(@ag-ui/client@0.0.44)(@ag-ui/core@0.0.44)(@ag-ui/encoder@0.0.44)(@copilotkitnext/shared@1.51.3)
       '@graphql-yoga/plugin-defer-stream': 3.17.1(graphql-yoga@5.17.1(graphql@16.12.0))(graphql@16.12.0)
       '@hono/node-server': 1.19.9(hono@4.11.4)
@@ -8905,12 +8912,12 @@ snapshots:
     optionalDependencies:
       '@anthropic-ai/sdk': 0.57.0
       '@langchain/aws': 0.1.15(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))
-      '@langchain/community': 0.3.58(bd036ef6774c128b7f50b46945ecc580)
+      '@langchain/community': 0.3.58(2ac5560405bf55a140234b821642e522)
       '@langchain/google-gauth': 0.1.8(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(zod@4.1.13)
       '@langchain/langgraph-sdk': 0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@langchain/openai': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(ws@8.19.0)
       groq-sdk: 0.5.0
-      langchain: 0.3.36(@langchain/aws@0.1.15(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(axios@1.13.4(debug@4.4.3))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))(ws@8.19.0)
+      langchain: 0.3.36(@langchain/aws@0.1.15(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(axios@1.13.4)(openai@4.104.0(ws@8.19.0)(zod@4.1.13))(ws@8.19.0)
       openai: 4.104.0(ws@8.19.0)(zod@4.1.13)
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -8930,14 +8937,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@copilotkitnext/agent@1.51.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)':
+  '@copilotkitnext/agent@1.51.3(@cfworker/json-schema@4.1.1)(hono@4.11.7)':
     dependencies:
       '@ag-ui/client': 0.0.42
       '@ai-sdk/anthropic': 2.0.58(zod@3.25.76)
       '@ai-sdk/google': 2.0.52(zod@3.25.76)
       '@ai-sdk/mcp': 0.0.8(zod@3.25.76)
       '@ai-sdk/openai': 2.0.89(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.7)(zod@3.25.76)
       ai: 5.0.125(zod@3.25.76)
       rxjs: 7.8.1
       zod: 3.25.76
@@ -9349,7 +9356,7 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@langchain/community@0.3.58(bd036ef6774c128b7f50b46945ecc580)':
+  '@langchain/community@0.3.58(2ac5560405bf55a140234b821642e522)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.57.0)(deepmerge@4.3.1)(dotenv@17.2.3)(openai@4.104.0(ws@8.19.0)(zod@4.1.13))(zod@4.1.13)
       '@ibm-cloud/watsonx-ai': 1.7.4
@@ -9360,7 +9367,7 @@ snapshots:
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.4.4
       js-yaml: 4.1.1
-      langchain: 0.3.36(@langchain/aws@0.1.15(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(axios@1.13.4(debug@4.4.3))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))(ws@8.19.0)
+      langchain: 0.3.36(@langchain/aws@0.1.15(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(axios@1.13.4)(openai@4.104.0(ws@8.19.0)(zod@4.1.13))(ws@8.19.0)
       langsmith: 0.3.87(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))
       math-expression-evaluator: 2.0.7
       openai: 4.104.0(ws@8.19.0)(zod@4.1.13)
@@ -9721,9 +9728,9 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.11.7)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.4)
+      '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -13325,7 +13332,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.4(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.4)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -13539,7 +13546,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  langchain@0.3.36(@langchain/aws@0.1.15(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(axios@1.13.4(debug@4.4.3))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))(ws@8.19.0):
+  langchain@0.3.36(@langchain/aws@0.1.15(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(axios@1.13.4)(openai@4.104.0(ws@8.19.0)(zod@4.1.13))(ws@8.19.0):
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13))
       '@langchain/openai': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.19.0)(zod@4.1.13)))(ws@8.19.0)
@@ -15300,7 +15307,9 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  retry-axios@2.6.0(axios@1.13.4(debug@4.4.3)):
+  resumable-stream@2.2.10: {}
+
+  retry-axios@2.6.0(axios@1.13.4):
     dependencies:
       axios: 1.13.4(debug@4.4.3)
     optional: true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import AiSdkWorkflowCustomEvents from "@/pages/ai-sdk/workflow-custom-events";
 import AiSdkWorkflowSuspendResume from "@/pages/ai-sdk/workflow-suspend-resume";
 import AiSdkWorkflowAgentTextStream from "@/pages/ai-sdk/workflow-agent-text-stream";
 import AiSdkToolNestedStreams from "@/pages/ai-sdk/tool-nested-streams";
+import AiSdkResumableStreams from "@/pages/ai-sdk/resumable-streams";
 import ClientToolsAiSdk from "@/pages/client-tools/ai-sdk";
 
 import ChatCopilotKit from "@/pages/copilot-kit";
@@ -74,6 +75,10 @@ export default function Page() {
                   <Route
                     path="tool-nested-streams"
                     element={<AiSdkToolNestedStreams />}
+                  />
+                  <Route
+                    path="resumable-streams"
+                    element={<AiSdkResumableStreams />}
                   />
                 </Route>
                 <Route path="/assistant-ui">

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -81,6 +81,15 @@ const SIDEBAR: SidebarEntry[] = [
         docsUrl: "https://mastra.ai/docs/frameworks/agentic-uis/ai-sdk",
       },
       {
+        id: "resumable-streams",
+        title: "Resume Streams",
+        url: "/ai-sdk/resumable-streams",
+        description: "Resume interrupted chat streams with useChat",
+        explanation:
+          "Demonstrates AI SDK resume streams with Mastra custom routes. A POST route starts a chat stream and stores its stream ID by chat ID, and a GET route reconnects with the latest stream so useChat({ resume: true }) can continue after refresh or reconnect.",
+        docsUrl: "https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-resume-streams",
+      },
+      {
         id: "sub-agents-and-workflows-custom-events",
         title: "Sub Agents & Workflows",
         url: "/ai-sdk/sub-agents-and-workflows-custom-events",

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -22,6 +22,11 @@ import { reportAgentNetwork } from "./agents/report-agent-network";
 import { weatherForecastAgent } from "./agents/weather-forecast-agent";
 import { planningAgent } from "./agents/planning-agent";
 import { hitlPlanningAgent } from "./agents/hitl-planning-agent";
+import {
+  resumableChatGetRoute,
+  resumableChatMessagesRoute,
+  resumableChatPostRoute,
+} from "./routes/resumable-chat-route";
 
 export const mastra = new Mastra({
   agents: {
@@ -91,6 +96,9 @@ export const mastra = new Mastra({
         path: "/network-custom-events",
         agent: "reportAgentNetwork",
       }),
+      resumableChatPostRoute,
+      resumableChatGetRoute,
+      resumableChatMessagesRoute,
       registerCopilotKit({
         path: "/copilotkit",
         resourceId: "copilotkit-resource",

--- a/src/mastra/routes/resumable-chat-route.ts
+++ b/src/mastra/routes/resumable-chat-route.ts
@@ -1,0 +1,243 @@
+import { randomUUID } from "node:crypto";
+import { handleChatStream, type ChatStreamHandlerParams } from "@mastra/ai-sdk";
+import { toAISdkV5Messages } from "@mastra/ai-sdk/ui";
+import { registerApiRoute } from "@mastra/core/server";
+import { createUIMessageStreamResponse, type UIMessage } from "ai";
+import {
+  createResumableStreamContext,
+  type Publisher,
+  type Subscriber,
+} from "resumable-stream/generic";
+
+const memoryKv = new Map<string, string>();
+const channelSubscribers = new Map<string, Set<(message: string) => void>>();
+
+const publisher: Publisher = {
+  connect: async () => undefined,
+  publish: async (channel, message) => {
+    const subscribers = channelSubscribers.get(channel);
+
+    if (!subscribers) {
+      return 0;
+    }
+
+    subscribers.forEach((callback) => callback(message));
+
+    return subscribers.size;
+  },
+  set: async (key, value) => {
+    memoryKv.set(key, value);
+    return "OK";
+  },
+  get: async (key) => memoryKv.get(key) ?? null,
+  incr: async (key) => {
+    const currentValue = Number(memoryKv.get(key) ?? "0");
+    const nextValue = currentValue + 1;
+
+    memoryKv.set(key, String(nextValue));
+
+    return nextValue;
+  },
+};
+
+const subscriber: Subscriber = {
+  connect: async () => undefined,
+  subscribe: async (channel, callback) => {
+    const subscribers = channelSubscribers.get(channel) ?? new Set();
+
+    subscribers.add(callback);
+    channelSubscribers.set(channel, subscribers);
+  },
+  unsubscribe: async (channel) => {
+    // Intentional for demo adapter: Subscriber API only supports channel-level unsubscribe.
+    // This app uses one logical subscriber set per stream channel.
+    channelSubscribers.delete(channel);
+  },
+};
+
+const resumableStreamContext = createResumableStreamContext({
+  waitUntil: null,
+  publisher,
+  subscriber,
+});
+
+const latestStreamByChatId = new Map<string, string>();
+
+const streamHeaders = {
+  "content-type": "text/event-stream; charset=utf-8",
+  "x-vercel-ai-ui-message-stream": "v1",
+  "cache-control": "no-store",
+};
+
+const toChatStreamParams = (
+  body: unknown,
+): ChatStreamHandlerParams<UIMessage> => {
+  const payload =
+    body && typeof body === "object"
+      ? (body as Record<string, unknown>)
+      : {};
+
+  const messages = Array.isArray(payload.messages)
+    ? (payload.messages as UIMessage[])
+    : [];
+
+  const lastMessage = messages.at(-1);
+
+  return {
+    messages: lastMessage ? [lastMessage] : [],
+    runId: typeof payload.runId === "string" ? payload.runId : undefined,
+    trigger:
+      payload.trigger === "submit-message" ||
+      payload.trigger === "regenerate-message"
+        ? payload.trigger
+        : undefined,
+    resumeData:
+      payload.resumeData && typeof payload.resumeData === "object"
+        ? (payload.resumeData as Record<string, unknown>)
+        : undefined,
+  };
+};
+
+export const resumableChatPostRoute = registerApiRoute(
+  "/custom/resumable-chat/:chatId",
+  {
+    method: "POST",
+    handler: async (c) => {
+      const { chatId } = c.req.param();
+      const mastra = c.get("mastra");
+      const requestBody = await c.req.json();
+      const chatParams = toChatStreamParams(requestBody);
+
+      const aiSdkStream = await handleChatStream({
+        mastra,
+        agentId: "ghibliAgent",
+        params: {
+          ...chatParams,
+          memory: {
+            thread: chatId,
+            resource: chatId,
+          },
+        },
+      });
+
+      const upstreamResponse = createUIMessageStreamResponse({
+        stream: aiSdkStream,
+      });
+
+      if (!upstreamResponse.body) {
+        return c.json(
+          {
+            error: "Failed to start stream",
+          },
+          500,
+        );
+      }
+
+      const streamId = randomUUID();
+      latestStreamByChatId.set(chatId, streamId);
+
+      const resumableStream = await resumableStreamContext.createNewResumableStream(
+        streamId,
+        () => upstreamResponse.body!.pipeThrough(new TextDecoderStream()),
+      );
+
+      if (!resumableStream) {
+        return c.json(
+          {
+            error: "Unable to create resumable stream",
+          },
+          500,
+        );
+      }
+
+      return new Response(resumableStream.pipeThrough(new TextEncoderStream()), {
+        headers: streamHeaders,
+      });
+    },
+  },
+);
+
+export const resumableChatGetRoute = registerApiRoute(
+  "/custom/resumable-chat/:chatId/stream",
+  {
+    method: "GET",
+    handler: async (c) => {
+      const { chatId } = c.req.param();
+      const streamId = latestStreamByChatId.get(chatId);
+
+      if (!streamId) {
+        return new Response(null, { status: 204 });
+      }
+
+      const existingStreamState = await resumableStreamContext.hasExistingStream(
+        streamId,
+      );
+
+      if (existingStreamState === "DONE") {
+        latestStreamByChatId.delete(chatId);
+        return new Response(null, { status: 204 });
+      }
+
+      if (existingStreamState === null) {
+        latestStreamByChatId.delete(chatId);
+        return new Response(null, { status: 204 });
+      }
+
+      const resumedStream = await resumableStreamContext.resumeExistingStream(
+        streamId,
+      );
+
+      if (!resumedStream) {
+        latestStreamByChatId.delete(chatId);
+        return new Response(null, { status: 204 });
+      }
+
+      return new Response(resumedStream.pipeThrough(new TextEncoderStream()), {
+        headers: streamHeaders,
+      });
+    },
+  },
+);
+
+export const resumableChatMessagesRoute = registerApiRoute(
+  "/custom/resumable-chat/:chatId/messages",
+  {
+    method: "GET",
+    handler: async (c) => {
+      try {
+        const { chatId } = c.req.param();
+        const mastra = c.get("mastra");
+        const agent = mastra.getAgent("ghibliAgent");
+        const memory = await agent.getMemory();
+
+        if (!memory) {
+          return c.json({ messages: [] });
+        }
+
+        const thread = await memory.getThreadById({ threadId: chatId });
+
+        if (!thread) {
+          return c.json({ messages: [] });
+        }
+
+        const recalled = await memory.recall({
+          threadId: chatId,
+          resourceId: chatId,
+          orderBy: {
+            field: "createdAt",
+            direction: "ASC",
+          },
+          perPage: 200,
+          page: 0,
+        });
+
+        return c.json({
+          messages: toAISdkV5Messages(recalled.messages),
+        });
+      } catch (error) {
+        console.error("Failed to load resumable chat messages", error);
+        return c.json({ messages: [] });
+      }
+    },
+  },
+);

--- a/src/pages/ai-sdk/network.tsx
+++ b/src/pages/ai-sdk/network.tsx
@@ -48,6 +48,7 @@ type StepStatus = NetworkData["steps"][number]["status"];
 
 const STATUS_MAP: Record<StepStatus, ToolUIPart["state"]> = {
   running: "input-available",
+  paused: "input-available",
   success: "output-available",
   failed: "output-error",
   suspended: "input-available",

--- a/src/pages/ai-sdk/resumable-streams.tsx
+++ b/src/pages/ai-sdk/resumable-streams.tsx
@@ -1,0 +1,300 @@
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from "@/components/ai-elements/conversation";
+import { Message, MessageContent } from "@/components/ai-elements/message";
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  type PromptInputMessage,
+  PromptInputFooter,
+} from "@/components/ai-elements/prompt-input";
+import { Response } from "@/components/ai-elements/response";
+import { Suggestion, Suggestions } from "@/components/ai-elements/suggestion";
+import { Loader } from "@/components/ai-elements/loader";
+import { Button } from "@/components/ui/button";
+import { MASTRA_BASE_URL } from "@/constants";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport, type UIMessage } from "ai";
+import { useEffect, useMemo, useState } from "react";
+
+const suggestions = [
+  "Tell me about Princess Mononoke",
+  "Who directed Spirited Away?",
+  "Recommend a Ghibli movie for first-time viewers",
+];
+
+const CHAT_ID_STORAGE_KEY = "ai-sdk-resumable-chat-id";
+
+const getOrCreateChatId = () => {
+  const existingId = window.localStorage.getItem(CHAT_ID_STORAGE_KEY);
+
+  if (existingId) {
+    return existingId;
+  }
+
+  const nextId = crypto.randomUUID();
+  window.localStorage.setItem(CHAT_ID_STORAGE_KEY, nextId);
+
+  return nextId;
+};
+
+const getMessageText = (message: UIMessage) =>
+  message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("")
+    .trim();
+
+const normalizeMessages = (messages: UIMessage[]): UIMessage[] => {
+  const lastIndexById = new Map<string, number>();
+
+  messages.forEach((message, index) => {
+    if (message.id) {
+      lastIndexById.set(message.id, index);
+    }
+  });
+
+  const dedupedById = messages.filter((message, index) => {
+    if (!message.id) {
+      return true;
+    }
+
+    return lastIndexById.get(message.id) === index;
+  });
+
+  const collapsed: UIMessage[] = [];
+
+  for (const message of dedupedById) {
+    const previous = collapsed.at(-1);
+
+    if (!previous) {
+      collapsed.push(message);
+      continue;
+    }
+
+    if (previous.role !== "assistant" || message.role !== "assistant") {
+      collapsed.push(message);
+      continue;
+    }
+
+    const previousText = getMessageText(previous);
+    const currentText = getMessageText(message);
+
+    if (!previousText || !currentText) {
+      collapsed.push(message);
+      continue;
+    }
+
+    if (currentText === previousText || previousText.startsWith(currentText)) {
+      continue;
+    }
+
+    if (currentText.startsWith(previousText)) {
+      collapsed[collapsed.length - 1] = message;
+      continue;
+    }
+
+    collapsed.push(message);
+  }
+
+  return collapsed;
+};
+
+const messageSignature = (message: UIMessage) =>
+  `${message.id ?? ""}:${message.role}:${getMessageText(message)}`;
+
+const hasSameMessageState = (a: UIMessage[], b: UIMessage[]) => {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every(
+    (message, index) => messageSignature(message) === messageSignature(b[index]),
+  );
+};
+
+const fetchMessagesForChat = async (chatId: string): Promise<UIMessage[]> => {
+  const response = await fetch(
+    `${MASTRA_BASE_URL}/custom/resumable-chat/${chatId}/messages`,
+  );
+
+  if (!response.ok) {
+    return [];
+  }
+
+  const data = (await response.json()) as { messages?: UIMessage[] };
+
+  if (!Array.isArray(data.messages)) {
+    return [];
+  }
+
+  return normalizeMessages(data.messages);
+};
+
+const ResumableStreamsDemo = () => {
+  const [input, setInput] = useState("");
+  const [chatId, setChatId] = useState(getOrCreateChatId);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(true);
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: `${MASTRA_BASE_URL}/custom/resumable-chat/${chatId}`,
+        prepareReconnectToStreamRequest: () => ({
+          api: `${MASTRA_BASE_URL}/custom/resumable-chat/${chatId}/stream`,
+        }),
+      }),
+    [chatId],
+  );
+
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  const { messages, setMessages, sendMessage, status } = useChat({
+    id: chatId,
+    resume: true,
+    transport,
+  });
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const loadMessages = async () => {
+      setIsLoadingHistory(true);
+      const serverMessages = await fetchMessagesForChat(chatId);
+
+      if (isCancelled) {
+        return;
+      }
+
+      setMessages(serverMessages);
+      setIsLoadingHistory(false);
+    };
+
+    void loadMessages();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [chatId, setMessages]);
+
+  useEffect(() => {
+    const normalizedMessages = normalizeMessages(messages);
+
+    if (!hasSameMessageState(normalizedMessages, messages)) {
+      setMessages(normalizedMessages);
+    }
+  }, [messages, setMessages]);
+
+  const handleSubmit = async (message: PromptInputMessage) => {
+    if (!message.text?.trim()) {
+      return;
+    }
+
+    try {
+      setSendError(null);
+      setInput("");
+      await sendMessage({ text: message.text });
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : "Failed to send message");
+    }
+  };
+
+  const handleSuggestionClick = async (suggestion: string) => {
+    try {
+      setSendError(null);
+      await sendMessage({ text: suggestion });
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : "Failed to send message");
+    }
+  };
+
+  const handleResetChatId = () => {
+    const nextChatId = crypto.randomUUID();
+
+    window.localStorage.setItem(CHAT_ID_STORAGE_KEY, nextChatId);
+    setSendError(null);
+    setMessages([]);
+    setChatId(nextChatId);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-0 md:p-6 relative size-full">
+      <div className="flex flex-col h-full gap-4">
+        <div className="flex items-center justify-between rounded-md border px-3 py-2 text-xs text-muted-foreground">
+          <span className="font-mono truncate">chatId: {chatId}</span>
+          <Button variant="outline" size="sm" onClick={handleResetChatId}>
+            New chat id
+          </Button>
+        </div>
+
+        <Conversation className="h-full">
+          <ConversationContent>
+            {messages.map((message) => {
+              const latestTextPart = message.parts
+                .filter((part) => part.type === "text")
+                .at(-1);
+
+              if (!latestTextPart) {
+                return null;
+              }
+
+              return (
+                <Message key={message.id} from={message.role}>
+                  <MessageContent>
+                    <Response>{latestTextPart.text}</Response>
+                  </MessageContent>
+                </Message>
+              );
+            })}
+
+            {(status === "submitted" || isLoadingHistory) && <Loader />}
+            {messages.length === 0 && !isLoadingHistory && (
+              <Suggestions>
+                {suggestions.map((suggestion) => (
+                  <Suggestion
+                    key={suggestion}
+                    suggestion={suggestion}
+                    onClick={handleSuggestionClick}
+                  />
+                ))}
+              </Suggestions>
+            )}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
+
+        <PromptInput onSubmit={handleSubmit} className="mt-auto">
+          <PromptInputBody>
+            <PromptInputTextarea
+              onChange={(e) => setInput(e.target.value)}
+              value={input}
+              placeholder="Start a message, then refresh the page while streaming..."
+            />
+          </PromptInputBody>
+          <PromptInputFooter>
+            <div
+              className={`flex items-center gap-2 text-xs ${sendError ? "text-destructive" : "text-muted-foreground"}`}
+            >
+              {sendError
+                ? `Send failed: ${sendError}`
+                : status === "streaming"
+                  ? "Streaming... Reload the page to test resume."
+                  : isLoadingHistory
+                    ? "Loading messages from Mastra memory..."
+                    : "Messages are loaded from Mastra memory (thread/resource = chatId)."}
+            </div>
+            <div className="flex items-center gap-2">
+              <PromptInputSubmit status={status} disabled={!input.trim()} />
+            </div>
+          </PromptInputFooter>
+        </PromptInput>
+      </div>
+    </div>
+  );
+};
+
+export default ResumableStreamsDemo;

--- a/src/pages/ai-sdk/workflow-suspend-resume.tsx
+++ b/src/pages/ai-sdk/workflow-suspend-resume.tsx
@@ -30,6 +30,7 @@ const STATUS_MAP: Record<
   ToolUIPart["state"]
 > = {
   running: "input-available",
+  paused: "input-available",
   waiting: "input-available",
   suspended: "input-available",
   success: "output-available",


### PR DESCRIPTION
## Summary
- add a new AI SDK page: **Resumable Streams** (`/ai-sdk/resumable-streams`)
- implement custom Mastra routes for resumable chat streaming:
  - `POST /custom/resumable-chat/:chatId`
  - `GET /custom/resumable-chat/:chatId/stream`
  - `GET /custom/resumable-chat/:chatId/messages`
- use `chatId` as Mastra memory `thread`/`resource`
- fetch chat history from Mastra memory instead of client-side message storage
- wire app route + sidebar link for the new demo
- include paused status map fixes in workflow/network examples

## Test Plan
- `pnpm run vite:build`
- manual check:
  - open `/ai-sdk/resumable-streams`
  - send a prompt and refresh during streaming to verify resume
  - refresh after completion to verify messages load from Mastra memory
  - click **New chat id** and verify a fresh thread starts
