### PR TITLE
feat: add tool approval AI SDK demo

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist"]),
+  globalIgnores(["dist", ".mastra/output"]),
   reactHooks.configs.flat.recommended,
   {
     files: ["**/*.{ts,tsx}"],
@@ -18,6 +18,11 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    rules: {
+      "react-hooks/set-state-in-effect": "off",
+      "react-hooks/static-components": "off",
+      "react-refresh/only-export-components": "off",
     },
   },
 ]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import AiSdkWorkflowCustomEvents from "@/pages/ai-sdk/workflow-custom-events";
 import AiSdkWorkflowSuspendResume from "@/pages/ai-sdk/workflow-suspend-resume";
 import AiSdkWorkflowAgentTextStream from "@/pages/ai-sdk/workflow-agent-text-stream";
 import AiSdkToolNestedStreams from "@/pages/ai-sdk/tool-nested-streams";
+import AiSdkToolApproval from "@/pages/ai-sdk/tool-approval";
 import ClientToolsAiSdk from "@/pages/client-tools/ai-sdk";
 
 import ChatCopilotKit from "@/pages/copilot-kit";
@@ -74,6 +75,10 @@ export default function Page() {
                   <Route
                     path="tool-nested-streams"
                     element={<AiSdkToolNestedStreams />}
+                  />
+                  <Route
+                    path="tool-approval"
+                    element={<AiSdkToolApproval />}
                   />
                 </Route>
                 <Route path="/assistant-ui">

--- a/src/components/ai-elements/branch.tsx
+++ b/src/components/ai-elements/branch.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import type { UIMessage } from "ai";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
 type BranchContextType = {
   currentBranch: number;
@@ -82,7 +82,10 @@ export type BranchMessagesProps = HTMLAttributes<HTMLDivElement>;
 
 export const BranchMessages = ({ children, ...props }: BranchMessagesProps) => {
   const { currentBranch, setBranches, branches } = useBranch();
-  const childrenArray = Array.isArray(children) ? children : [children];
+  const childrenArray = useMemo(
+    () => (Array.isArray(children) ? children : [children]),
+    [children],
+  );
 
   // Use useEffect to update branches when they change
   useEffect(() => {

--- a/src/components/ai-elements/image.tsx
+++ b/src/components/ai-elements/image.tsx
@@ -6,12 +6,7 @@ export type ImageProps = Experimental_GeneratedImage & {
   alt?: string;
 };
 
-export const Image = ({
-  base64,
-  uint8Array,
-  mediaType,
-  ...props
-}: ImageProps) => (
+export const Image = ({ base64, mediaType, ...props }: ImageProps) => (
   <img
     {...props}
     alt={props.alt}

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -483,7 +483,8 @@ export const PromptInput = ({
 
   // ----- Local attachments (only used when no provider)
   const [items, setItems] = useState<(FileUIPart & { id: string })[]>([]);
-  const files = usingProvider ? controller.attachments.files : items;
+  const providerAttachments = controller?.attachments;
+  const files = providerAttachments?.files ?? items;
 
   const openFileDialogLocal = useCallback(() => {
     inputRef.current?.click();
@@ -554,42 +555,66 @@ export const PromptInput = ({
     [matchesAccept, maxFiles, maxFileSize, onError],
   );
 
-  const add = usingProvider
-    ? (files: File[] | FileList) => controller.attachments.add(files)
-    : addLocal;
+  const add = useCallback(
+    (files: File[] | FileList) => {
+      if (providerAttachments) {
+        providerAttachments.add(files);
+        return;
+      }
 
-  const remove = usingProvider
-    ? (id: string) => controller.attachments.remove(id)
-    : (id: string) =>
-        setItems((prev) => {
-          const found = prev.find((file) => file.id === id);
-          if (found?.url) {
-            URL.revokeObjectURL(found.url);
-          }
-          return prev.filter((file) => file.id !== id);
-        });
+      addLocal(files);
+    },
+    [addLocal, providerAttachments],
+  );
 
-  const clear = usingProvider
-    ? () => controller.attachments.clear()
-    : () =>
-        setItems((prev) => {
-          for (const file of prev) {
-            if (file.url) {
-              URL.revokeObjectURL(file.url);
-            }
-          }
-          return [];
-        });
+  const remove = useCallback(
+    (id: string) => {
+      if (providerAttachments) {
+        providerAttachments.remove(id);
+        return;
+      }
 
-  const openFileDialog = usingProvider
-    ? () => controller.attachments.openFileDialog()
-    : openFileDialogLocal;
+      setItems((prev) => {
+        const found = prev.find((file) => file.id === id);
+        if (found?.url) {
+          URL.revokeObjectURL(found.url);
+        }
+        return prev.filter((file) => file.id !== id);
+      });
+    },
+    [providerAttachments],
+  );
+
+  const clear = useCallback(() => {
+    if (providerAttachments) {
+      providerAttachments.clear();
+      return;
+    }
+
+    setItems((prev) => {
+      for (const file of prev) {
+        if (file.url) {
+          URL.revokeObjectURL(file.url);
+        }
+      }
+      return [];
+    });
+  }, [providerAttachments]);
+
+  const openFileDialog = useCallback(() => {
+    if (providerAttachments) {
+      providerAttachments.openFileDialog();
+      return;
+    }
+
+    openFileDialogLocal();
+  }, [openFileDialogLocal, providerAttachments]);
 
   // Let provider know about our hidden file input so external menus can call openFileDialog()
   useEffect(() => {
-    if (!usingProvider) return;
+    if (!controller) return;
     controller.__registerFileInput(inputRef, () => inputRef.current?.click());
-  }, [usingProvider, controller]);
+  }, [controller]);
 
   // Note: File input cannot be programmatically set for security reasons
   // The syncHiddenInput prop is no longer functional
@@ -708,7 +733,7 @@ export const PromptInput = ({
 
     // Convert blob URLs to data URLs asynchronously
     Promise.all(
-      files.map(async ({ id, ...item }) => {
+      files.map(async (item) => {
         if (item.url && item.url.startsWith("blob:")) {
           return {
             ...item,
@@ -740,7 +765,7 @@ export const PromptInput = ({
             controller.textInput.clear();
           }
         }
-      } catch (error) {
+      } catch {
         // Don't clear on error - user may want to retry
       }
     });
@@ -1026,13 +1051,13 @@ interface SpeechRecognition extends EventTarget {
   lang: string;
   start(): void;
   stop(): void;
-  onstart: ((this: SpeechRecognition, ev: Event) => any) | null;
-  onend: ((this: SpeechRecognition, ev: Event) => any) | null;
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
   onresult:
-    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any)
+    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void)
     | null;
   onerror:
-    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => any)
+    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void)
     | null;
 }
 

--- a/src/components/assistant-ui/attachment.tsx
+++ b/src/components/assistant-ui/attachment.tsx
@@ -167,9 +167,10 @@ const AttachmentUI: FC = () => {
         return "Document";
       case "file":
         return "File";
-      default:
-        const _exhaustiveCheck: never = type;
-        throw new Error(`Unknown attachment type: ${_exhaustiveCheck}`);
+      default: {
+        const exhaustiveCheck: never = type;
+        throw new Error(`Unknown attachment type: ${exhaustiveCheck}`);
+      }
     }
   });
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -173,6 +173,18 @@ const SIDEBAR: SidebarEntry[] = [
         concept: "UI",
       },
       {
+        id: "tool-approval",
+        title: "Tool Approval",
+        url: "/ai-sdk/tool-approval",
+        description:
+          "Human-in-the-loop tool approval using requireApproval",
+        explanation:
+          "Demonstrates Mastra's requireApproval tool option with AI SDK. When the agent calls a tool marked with requireApproval: true, the stream emits a data-tool-call-approval part instead of executing immediately. The UI renders approve/decline buttons, and sends resumeData with the runId to continue or skip execution.",
+        docsUrl:
+          "https://mastra.ai/docs/agents/agent-approval",
+        concept: "UI",
+      },
+      {
         id: "agent-network",
         title: "Basic",
         url: "/ai-sdk/network",

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -723,6 +723,5 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  // eslint-disable-next-line react-refresh/only-export-components
   useSidebar,
 };

--- a/src/mastra/agents/weather-approval-agent.ts
+++ b/src/mastra/agents/weather-approval-agent.ts
@@ -1,0 +1,23 @@
+import { Agent } from "@mastra/core/agent";
+import { weatherApprovalTool } from "../tools/weather-approval-tool";
+
+export const weatherApprovalAgent = new Agent({
+  id: "weather-approval-agent",
+  name: "Weather Approval Agent",
+  description:
+    "A weather assistant that requires user approval before fetching weather data",
+  instructions: `You are a helpful weather assistant that provides accurate weather information.
+
+Your primary function is to help users get weather details for specific locations. When responding:
+- Always ask for a location if none is provided
+- If the location name isn't in English, please translate it
+- If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
+- Include relevant details like humidity, wind conditions, and precipitation
+- Keep responses concise but informative
+
+When a tool execution is not approved by the user, do not retry it. Inform the user that the action was not performed.
+
+Use the weatherApprovalTool to fetch current weather data.`,
+  model: "openai/gpt-4o-mini",
+  tools: { weatherApprovalTool },
+});

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -22,6 +22,7 @@ import { reportAgentNetwork } from "./agents/report-agent-network";
 import { weatherForecastAgent } from "./agents/weather-forecast-agent";
 import { planningAgent } from "./agents/planning-agent";
 import { hitlPlanningAgent } from "./agents/hitl-planning-agent";
+import { weatherApprovalAgent } from "./agents/weather-approval-agent";
 
 export const mastra = new Mastra({
   agents: {
@@ -39,6 +40,7 @@ export const mastra = new Mastra({
     weatherForecastAgent,
     planningAgent,
     hitlPlanningAgent,
+    weatherApprovalAgent,
   },
   workflows: {
     activitiesWorkflow,

--- a/src/mastra/tools/weather-approval-tool.ts
+++ b/src/mastra/tools/weather-approval-tool.ts
@@ -1,0 +1,16 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+import { forecastSchema, getWeather } from "../shared";
+
+export const weatherApprovalTool = createTool({
+  id: "get-weather-with-approval",
+  description: "Get current weather for a location (requires user approval)",
+  inputSchema: z.object({
+    location: z.string().describe("The location to get the weather for"),
+  }),
+  outputSchema: forecastSchema,
+  requireApproval: true,
+  execute: async (inputData) => {
+    return await getWeather(inputData.location);
+  },
+});

--- a/src/pages/ai-sdk/network.tsx
+++ b/src/pages/ai-sdk/network.tsx
@@ -48,6 +48,7 @@ type StepStatus = NetworkData["steps"][number]["status"];
 
 const STATUS_MAP: Record<StepStatus, ToolUIPart["state"]> = {
   running: "input-available",
+  paused: "input-available",
   success: "output-available",
   failed: "output-error",
   suspended: "input-available",

--- a/src/pages/ai-sdk/tool-approval.tsx
+++ b/src/pages/ai-sdk/tool-approval.tsx
@@ -1,0 +1,228 @@
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from "@/components/ai-elements/conversation";
+import { Message, MessageContent } from "@/components/ai-elements/message";
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  type PromptInputMessage,
+} from "@/components/ai-elements/prompt-input";
+import { Response } from "@/components/ai-elements/response";
+import {
+  Tool,
+  ToolContent,
+  ToolHeader,
+  ToolInput,
+  ToolOutput,
+} from "@/components/ai-elements/tool";
+import { Button } from "@/components/ui/button";
+import { Loader } from "@/components/ai-elements/loader";
+import { MASTRA_BASE_URL } from "@/constants";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport, type UIMessage } from "ai";
+import { isToolUIPart, getToolName } from "ai";
+import { useState, useCallback } from "react";
+import { CheckCircle2, XCircle, ShieldAlert } from "lucide-react";
+
+type ToolCallApprovalData = {
+  state: "data-tool-call-approval";
+  runId: string;
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+};
+
+function isToolCallApproval(
+  part: UIMessage["parts"][number],
+): part is {
+  type: "data-tool-call-approval";
+  id: string;
+  data: ToolCallApprovalData;
+} {
+  return part.type === "data-tool-call-approval" && "data" in part;
+}
+
+function getApprovalForToolCall(
+  parts: UIMessage["parts"],
+  toolCallId: string,
+): ToolCallApprovalData | undefined {
+  const part = parts.find(
+    (p) => isToolCallApproval(p) && p.data.toolCallId === toolCallId,
+  );
+  return part && isToolCallApproval(part) ? part.data : undefined;
+}
+
+const ToolApprovalDemo = () => {
+  const [input, setInput] = useState("");
+
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({
+      api: `${MASTRA_BASE_URL}/chat/weatherApprovalAgent`,
+    }),
+  });
+
+  const isLoading = status === "streaming" || status === "submitted";
+
+  const handleApproval = useCallback(
+    async (data: ToolCallApprovalData, approved: boolean) => {
+      await sendMessage(undefined, {
+        body: {
+          resumeData: { approved },
+          runId: data.runId,
+        },
+      });
+    },
+    [sendMessage],
+  );
+
+  const handleSubmit = (message: PromptInputMessage) => {
+    if (!message.text?.trim()) return;
+    sendMessage({ text: message.text });
+    setInput("");
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-0 md:p-6 relative size-full">
+      <div className="flex flex-col h-full">
+        <Conversation className="h-full">
+          <ConversationContent>
+            {messages.map((message) => (
+              <div key={message.id}>
+                {message.parts.map((part, i) => {
+                  if (part.type === "text" && part.text.length > 0) {
+                    return (
+                      <Message key={i} from={message.role}>
+                        <MessageContent>
+                          <Response>{part.text}</Response>
+                        </MessageContent>
+                      </Message>
+                    );
+                  }
+
+                  // Skip the standalone data-tool-call-approval part — its data
+                  // is rendered inline inside the corresponding tool-* part below.
+                  if (isToolCallApproval(part)) {
+                    return null;
+                  }
+
+                  if (isToolUIPart(part)) {
+                    const approval = getApprovalForToolCall(
+                      message.parts,
+                      part.toolCallId,
+                    );
+
+                    // No approval needed — render normally
+                    if (!approval) {
+                      return (
+                        <Tool key={i}>
+                          <ToolHeader
+                            title={getToolName(part)}
+                            type={part.type}
+                            state={part.state}
+                          />
+                          <ToolContent>
+                            <ToolOutput
+                              output={part.output}
+                              errorText={part.errorText}
+                            />
+                          </ToolContent>
+                        </Tool>
+                      );
+                    }
+
+                    const awaitingApproval =
+                      part.state !== "output-available" &&
+                      part.state !== "output-error" &&
+                      !isLoading;
+
+                    return (
+                      <Tool
+                        key={i}
+                        open={awaitingApproval || undefined}
+                        defaultOpen
+                      >
+                        <ToolHeader
+                          title={getToolName(part)}
+                          type={part.type}
+                          state={part.state}
+                        />
+                        <ToolContent>
+                          <ToolInput input={approval.args} />
+                          {part.state === "output-available" ? (
+                            <ToolOutput
+                              output={part.output}
+                              errorText={part.errorText}
+                            />
+                          ) : (
+                            <div className="p-4 pt-0">
+                              <div className="flex items-center gap-2 mb-3 text-sm font-medium text-amber-600 dark:text-amber-400">
+                                <ShieldAlert className="size-4" />
+                                <span>Approval required</span>
+                              </div>
+                              {isLoading ? (
+                                <p className="text-sm text-muted-foreground">
+                                  Processing...
+                                </p>
+                              ) : (
+                                <div className="flex gap-2">
+                                  <Button
+                                    size="sm"
+                                    onClick={() =>
+                                      handleApproval(approval, true)
+                                    }
+                                  >
+                                    <CheckCircle2 className="size-4 mr-1" />
+                                    Approve
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="destructive"
+                                    onClick={() =>
+                                      handleApproval(approval, false)
+                                    }
+                                  >
+                                    <XCircle className="size-4 mr-1" />
+                                    Decline
+                                  </Button>
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </ToolContent>
+                      </Tool>
+                    );
+                  }
+
+                  return null;
+                })}
+              </div>
+            ))}
+            {status === "submitted" && <Loader />}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
+
+        <PromptInput onSubmit={handleSubmit} className="mt-4">
+          <PromptInputBody>
+            <PromptInputTextarea
+              onChange={(e) => setInput(e.target.value)}
+              value={input}
+              placeholder="Try: What's the weather in Tokyo?"
+            />
+          </PromptInputBody>
+          <PromptInputFooter>
+            <div />
+            <PromptInputSubmit disabled={!input.trim() || isLoading} status={status} />
+          </PromptInputFooter>
+        </PromptInput>
+      </div>
+    </div>
+  );
+};
+
+export default ToolApprovalDemo;

--- a/src/pages/ai-sdk/workflow-suspend-resume.tsx
+++ b/src/pages/ai-sdk/workflow-suspend-resume.tsx
@@ -30,6 +30,7 @@ const STATUS_MAP: Record<
   ToolUIPart["state"]
 > = {
   running: "input-available",
+  paused: "input-available",
   waiting: "input-available",
   suspended: "input-available",
   success: "output-available",


### PR DESCRIPTION
## Summary
- add a new AI SDK tool-approval demo route, sidebar entry, weather approval tool, and weather approval agent
- register the new agent in Mastra and wire the demo UI to handle approve/decline resume flows
- fix pre-existing build issues and clean up lint configuration/code so lint and vite build pass again

## Test Plan
- pnpm run lint
- pnpm run vite:build