### PR TITLE
Show previous_response_id in Responses API demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .mastra
-src/mastra/public/*.db
+src/mastra/public/*.db*
 
 .env

--- a/src/pages/mastra-client-sdk/responses-api.tsx
+++ b/src/pages/mastra-client-sdk/responses-api.tsx
@@ -188,6 +188,10 @@ export default function ResponsesApiPage() {
           ))}
         </Suggestions>
 
+        <div className="mt-3 rounded-md border border-border/60 bg-muted/40 px-3 py-2 font-mono text-[11px] text-muted-foreground">
+          previous_response_id: {previousResponseId ?? "null"}
+        </div>
+
         <PromptInput className="mt-4" onSubmit={handleSubmit}>
           <PromptInputBody>
             <PromptInputTextarea


### PR DESCRIPTION
## Summary
- show the current `previous_response_id` in the Responses API demo UI
- keep the display simple and inline as debug metadata
- ignore generated SQLite sidecar files under `src/mastra/public`

## Verification
- pnpm run lint
- pnpm run vite:build